### PR TITLE
Orthogonal lines and improved snapping

### DIFF
--- a/lib/Editor/Control/FixedAngleDrawing.js
+++ b/lib/Editor/Control/FixedAngleDrawing.js
@@ -68,6 +68,7 @@ OpenLayers.Editor.Control.FixedAngleDrawing = OpenLayers.Class(OpenLayers.Contro
         this.sketchVerticesAmount = vertices.length;
         var snappingGuideLayer = this.getSnappingGuideLayer();
         if (vertices.length === 2) {
+            // Add two guides orthogonal to the first point
             this.guides.push(snappingGuideLayer.addLine({
                 m: Infinity,
                 x: vertices[0].x
@@ -76,6 +77,8 @@ OpenLayers.Editor.Control.FixedAngleDrawing = OpenLayers.Class(OpenLayers.Contro
                 m: Infinity,
                 y: vertices[0].y
             }));
+            // Avoid to add the first point as snapping point
+            snappingGuideLayer.rebuildIntersectionPoints(vertices[0]);
             return;
         }
 
@@ -96,6 +99,7 @@ OpenLayers.Editor.Control.FixedAngleDrawing = OpenLayers.Class(OpenLayers.Contro
             m: m2,
             b: b2
         }));
+        snappingGuideLayer.rebuildIntersectionPoints();
     },
 
     /**

--- a/lib/Editor/Layer/Snapping.js
+++ b/lib/Editor/Layer/Snapping.js
@@ -143,7 +143,8 @@ OpenLayers.Editor.Layer.Snapping = OpenLayers.Class(OpenLayers.Layer.Vector, {
         this.addFeatures([
             guideLine
         ]);
-        this.rebuildIntersectionPoints();
+        // called explicitely at the end of the "addline" process
+        // this.rebuildIntersectionPoints();
         return guideLine;
     },
 
@@ -171,7 +172,7 @@ OpenLayers.Editor.Layer.Snapping = OpenLayers.Class(OpenLayers.Layer.Vector, {
     /**
      * Discards previous snapping points and adds new snapping points at guide line intersections.
      */
-    rebuildIntersectionPoints: function () {
+    rebuildIntersectionPoints: function (pointToSkip) {
         var maxExtent = this.map.getMaxExtent();
         var intersectionOptions = {
             point: true,
@@ -205,18 +206,20 @@ OpenLayers.Editor.Layer.Snapping = OpenLayers.Class(OpenLayers.Layer.Vector, {
                         }
 
                         var pointToAdd = new OpenLayers.Geometry.Point(intersection.x, intersection.y);
+                        // Check if point should be checked
+                        if (pointToSkip) {
+                            if (pointToAdd.equals(pointToSkip)) {
+                                return;
+                            }
+                        }
                         // Check if point was already added
-                        var found = false;
                         for (var i = 0; i < this.intersectionPoints.length; i++) {
                             var pointToCheck = this.intersectionPoints[i].geometry;
                             if (pointToAdd.equals(pointToCheck)) {
-                                found = true;
-                                break;
+                                return;
                             }
                         }
-                        if (!found) {
-                            this.intersectionPoints.push(new OpenLayers.Feature.Vector(pointToAdd));
-                        }
+                        this.intersectionPoints.push(new OpenLayers.Feature.Vector(pointToAdd));
                     }, this);
                 }, this);
             }, this);


### PR DESCRIPTION
I've maybe **improved** the guided drawing. 
Now, after the first point added, two orthogonal guided lines are drawn.
In addition, intersetcions are made with _OpenLayers.Geometry.segmentsIntersect_, that works also with orthogonal lines, where the original code doesn't works.
Hope this helps.
